### PR TITLE
Added support to point to other repositories when generating themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ To test it locally, add the root of the baseUrl as first argument:
 ```
 ./generateThemeSite.sh http://localhost:1313
 ```
+
+To alter the Hugo themes repository used (contains all themes to display),
+provide a value for the environment variable `HUGO_THEMES_REPO`.
+
+```
+HUGO_THEMES_REPO=<repo> ./generateThemeSite.sh http://localhost:1313
+```
+
+To alter the Hugo theme site repository used, provide a value for the
+environment variable `HUGO_THEME_SITE_REPO`.
+
+```
+HUGO_THEME_SITE_REPO=<repo> ./generateThemeSite.sh http://localhost:1313
+```
+
+To alter the Hugo example site repository used, provide a value for the
+environment variable `HUGO_EXAMPLE_SITE_REPO`.
+
+```
+HUGO_EXAMPLE_SITE_REPO=<repo> ./generateThemeSite.sh http://localhost:1313
+```
+

--- a/generateThemeSite.sh
+++ b/generateThemeSite.sh
@@ -20,6 +20,15 @@ function fixReadme {
 	echo "$content"
 }
 
+# Load the repositories from the provided environment variables or our defaults
+HUGO_THEME_SITE_REPO=${HUGO_THEME_SITE_REPO:-https://github.com/spf13/HugoThemesSite.git}
+HUGO_BASIC_EXAMPLE_REPO=${HUGO_BASIC_EXAMPLE_REPO:-https://github.com/spf13/HugoBasicExample.git}
+HUGO_THEMES_REPO=${HUGO_THEMES_REPO:-https://github.com/spf13/hugoThemes.git}
+
+echo "Using ${HUGO_THEMES_REPO} for themes"
+echo "Using ${HUGO_THEME_SITE_REPO} for theme site"
+echo "Using ${HUGO_BASIC_EXAMPLE_REPO} for example site"
+
 GLOBIGNORE=.*
 siteDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/hugoThemeSite"
 
@@ -36,14 +45,14 @@ if [ -d themeSite ]; then
 	git pull --rebase
 	cd ..
 else
-	git clone https://github.com/spf13/HugoThemesSite.git themeSite  
+	git clone ${HUGO_THEME_SITE_REPO} themeSite  
 fi
 if [ -d exampleSite ]; then
 	cd exampleSite
 	git pull --rebase
 	cd ..
 else
-	git clone https://github.com/spf13/HugoBasicExample.git exampleSite
+	git clone ${HUGO_BASIC_EXAMPLE_REPO} exampleSite
 fi
 
 cd exampleSite
@@ -54,7 +63,7 @@ if [ -d themes ]; then
 	git submodule update --init --recursive
 	cd ..
 else
-	git clone --recursive https://github.com/spf13/hugoThemes.git themes
+	git clone --recursive ${HUGO_THEMES_REPO} themes
 fi
 
 cd ..


### PR DESCRIPTION
You can close this if you don't want it, but this is what I used to test my fork of the Hugo themes with my changes such that I can generate a different commit of my submodule without needing to push it to you.

For issue #5.