### PR TITLE
Perl command fix for disabling shortcodes

### DIFF
--- a/generateThemeSite.sh
+++ b/generateThemeSite.sh
@@ -15,8 +15,8 @@ function fixReadme {
   # Make images viewable outside GitHub
   content=$( echo "$content" | perl -p -e 's/github\.com\/(.*?)\/blob\/master\/images/raw\.githubusercontent\.com\/$1\/master\/images/g;' )
   # Tell Hugo not to process shortcode samples
-  content=$( echo "$content" | perl -p -e 's/{{%(.*?)%}}/{{%\/*$1*\/%}}/g;' )
-  content=$( echo "$content" | perl -p -e 's/{{<(.*?)>}}/{{<\/*$1*\/>}}/g;' )
+  content=$( echo "$content" | perl -0pe 's/{{%(.*?)%}}/{{%\/*$1*\/%}}/sg;' )
+  content=$( echo "$content" | perl -0pe 's/{{<(.*?)>}}/{{<\/*$1*\/>}}/sg;' )
   
   echo "$content"
 }


### PR DESCRIPTION
Hello, I've altered the perl command so that it can handle multiline shortcodes. This fix should resolve the following issue, https://github.com/spf13/hugoThemes/issues/119. Thanks